### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-##Grunt setup for a Laravel environment. 
+## Grunt setup for a Laravel environment. 
 
 These are the files for the article published on [my blog](http://blog.elenakolevska.com/using-grunt-with-laravel-and-bootstrap/) in english and on [laravel.com.br](http://www.laravel.com.br/?p=508) in portugues.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
